### PR TITLE
Wos unhashable list error

### DIFF
--- a/tethne/classes/corpus.py
+++ b/tethne/classes/corpus.py
@@ -283,7 +283,10 @@ class Corpus(object):
                 m.update(hashable.encode('utf-8'))
                 setattr(paper, 'hashIndex', m.hexdigest())
             return getattr(paper, 'hashIndex')
-        return getattr(paper, self.index_by)    # Identifier is already available.
+        identifier = getattr(paper,self.index_by)
+        if isinstance(identifier,list):
+          identifier = getattr(paper,self.index_by)[0]
+        return identifier    # Identifier is already available.
 
     def index_feature(self, feature_name, tokenize=lambda x: x, structured=False):
         """

--- a/tethne/readers/base.py
+++ b/tethne/readers/base.py
@@ -149,7 +149,7 @@ class IterParser(BaseParser):
         if hasattr(self.data[-1], tag):
             value = getattr(self.data[-1], tag)
             if tag in self.concat_fields:
-                value = ' '.join([value, data])
+                value = ' '.join([value, str(data)])
             elif type(value) is list:
                 value.append(data)
             elif value not in [None, '']:

--- a/tethne/tests/test_utilities.py
+++ b/tethne/tests/test_utilities.py
@@ -10,6 +10,9 @@ from tethne.utilities import overlap
 from tethne.utilities import _strip_punctuation
 from tethne.utilities import strip_punctuation
 from tethne.utilities import Dictionary
+from tethne.utilities import attribs_to_string
+from tethne.utilities import argmax
+from tethne.utilities import contains
 
 from tethne.utilities import strip_non_ascii
 
@@ -99,6 +102,38 @@ class TestGetItem(unittest.TestCase):
 
         Dictionary.__setitem__(dict_obj,'str',8)
         self.assertEqual(8,Dictionary.__getitem__(dict_obj,'str'))
+
+#method not changing anything much
+class TestAttribsToString(unittest.TestCase):
+
+    def test_attribs(self):
+        present_dict = { 1:[2,4,6,8], 2:(7,14), 3:{10:20}, 4:100, 5:300, 6:400}
+
+        self.assertEqual(present_dict,attribs_to_string(present_dict,None))
+
+class TestArgMax(unittest.TestCase):
+
+    def test_arg_max_str(self):
+        iterable = ['efgh','abcd','jklm','poqr']
+        self.assertEqual(3,argmax(iterable))
+
+    def test_arg_max_num(self):
+        iterable = [30,10,40,20]
+        self.assertEqual(2,argmax(iterable))
+
+class TestContains(unittest.TestCase):
+
+    def test_contains_true(self):
+        l = [2,4,1,6]
+        f = lambda x: x %2 == 1
+
+        self.assertEqual(True,contains(l,f))
+
+    def test_contains_false(self):
+        l = [0,2,4,8]
+        f = lambda x: x%2 == 1
+
+        self.assertEqual(False,contains(l,f))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixed following two errors:
1) In base.py, modified 
             value = ' '.join([value, data])  to value = ' '.join([value, str(data)]) 
    so that it handles int in the "data" even if it is something like "2007". Where earlier it was throwing error. 
2) In corpus.py, added the lines to handle the unhashable list error. 
