### PR TITLE
Unhashable list error fixed

### DIFF
--- a/tethne/classes/corpus.py
+++ b/tethne/classes/corpus.py
@@ -283,7 +283,10 @@ class Corpus(object):
                 m.update(hashable.encode('utf-8'))
                 setattr(paper, 'hashIndex', m.hexdigest())
             return getattr(paper, 'hashIndex')
-        return getattr(paper, self.index_by)    # Identifier is already available.
+        identifier = getattr(paper,self.index_by)
+        if isinstance(identifier,list):
+          identifier = getattr(paper,self.index_by)[0]
+        return identifier    # Identifier is already available.
 
     def index_feature(self, feature_name, tokenize=lambda x: x, structured=False):
         """

--- a/tethne/readers/base.py
+++ b/tethne/readers/base.py
@@ -149,7 +149,7 @@ class IterParser(BaseParser):
         if hasattr(self.data[-1], tag):
             value = getattr(self.data[-1], tag)
             if tag in self.concat_fields:
-                value = ' '.join([value, data])
+                value = ' '.join([value, str(data)])
             elif type(value) is list:
                 value.append(data)
             elif value not in [None, '']:

--- a/tethne/readers/base.py
+++ b/tethne/readers/base.py
@@ -149,7 +149,7 @@ class IterParser(BaseParser):
         if hasattr(self.data[-1], tag):
             value = getattr(self.data[-1], tag)
             if tag in self.concat_fields:
-                value = ' '.join([value, str(data)])
+                value = ' '.join([value, unicode(data)])
             elif type(value) is list:
                 value.append(data)
             elif value not in [None, '']:


### PR DESCRIPTION
Fixed following two errors:
1) In base.py, modified
value = ' '.join([value, data]) to value = ' '.join([value, str(data)])
so that it handles int in the "data" even if it is something like "2007". Where earlier it was throwing error.
2) In corpus.py, added the lines to handle the unhashable list error. 
