### PR TITLE
Zotero Reader : JIRA issues 119 and 120 fixed

### DIFF
--- a/tethne/readers/zotero.py
+++ b/tethne/readers/zotero.py
@@ -247,12 +247,53 @@ class ZoteroParser(RDFParser):
                     pass
 
     def handle_documentType(self, value):
-        return value
+        """
+
+        Parameters
+        ----------
+        value
+
+        Returns
+        -------
+        value.toPython()
+        Basically, RDF literals are casted to their corresponding Python data types.
+        """
+        return value.toPython()
 
     def handle_authors_full(self, value):
         authors = [self.handle_author(o) for s, p, o
                    in self.graph.triples((value, None, None))]
         return [a for a in authors if a is not None]
+
+    def handle_abstract(self, value):
+        """
+        Abstract handler.
+
+        Parameters
+        ----------
+        value
+
+        Returns
+        -------
+        abstract.toPython()
+        Basically, RDF literals are casted to their corresponding Python data types.
+        """
+        return value.toPython()
+
+    def handle_title(self, value):
+        """
+        Title handler
+        Parameters
+        ----------
+        value
+
+        Returns
+        -------
+        title.toPython()
+
+        """
+        return value.toPython()
+
 
     def handle_author(self, value):
         forename_iter = self.graph.triples((value, FORENAME_ELEM, None))

--- a/tethne/tests/test_readers_zotero.py
+++ b/tethne/tests/test_readers_zotero.py
@@ -68,6 +68,34 @@ class TestZoteroParser(unittest.TestCase):
         self.assertIsInstance(papers, list)
         self.assertIsInstance(papers[0], Paper)
 
+    def test_authors(self):
+        """
+        Tests for empty author names for each paper in a ZOTERO Corpus
+
+        Returns
+        -------
+        Fails : When the author-name is empty, it fails
+
+        """
+        papers = read(datapath)
+        for paper in papers:
+            self.assertNotEqual(len(paper.authors), 0, "Author list cannot be empty")
+
+
+    def test_authors_full(self):
+        """
+        Tests for empty author_full names for each paper in a ZOTERO Corpus
+
+        Returns
+        -------
+        Fails : When the author_full names is empty, it fails.
+
+        """
+        papers = read(datapath)
+        for paper in papers:
+            self.assertNotEqual(len(paper.authors_full), 0, "Author_full list cannot be empty")
+
+
     def test_handle_date(self):
         parser = ZoteroParser(datapath)
         parser.parse()


### PR DESCRIPTION
Fixed JIRA 119 - To cast RDF literals to Python Datatypes
and JIRA 120 - To access the author names from Paper object. 
