### PR TITLE
Parse wc

### DIFF
--- a/tethne/readers/wos.py
+++ b/tethne/readers/wos.py
@@ -85,7 +85,6 @@ class WoSParser(FTParser):
         'SE': 'bookSeriesTitle',
         'BS': 'bookSeriesSubtitle',
         'LA': 'language',
-        'DT': 'documentType',
         'CT': 'conferenceTitle',
         'CY': 'conferenceDate',
         'HO': 'conferenceHost',

--- a/tethne/readers/wos.py
+++ b/tethne/readers/wos.py
@@ -226,6 +226,19 @@ class WoSParser(FTParser):
         setattr(citation, 'doi', doi)
         return citation
 
+    def postprocess_WC(self, entry):
+        """
+        Parse WC keywords.
+
+        Subject keywords are usually semicolon-delimited.
+        """
+
+        if type(entry.WC) not in [str, unicode]:
+            WC= u' '.join([unicode(k) for k in entry.WC])
+        else:
+            WC= entry.WC
+        entry.WC= [k.strip().upper() for k in WC.split(';')]
+
     def postprocess_subject(self, entry):
         """
         Parse subject keywords.

--- a/tethne/tests/test_readers_wos.py
+++ b/tethne/tests/test_readers_wos.py
@@ -71,6 +71,10 @@ class TestWoSParser(unittest.TestCase):
                 self.assertIsInstance(e.abstract, unicode,
                                       derror.format('abstract', 'unicode',
                                                     type(e.abstract)))
+            if hasattr(e, 'WC'):
+                self.assertIsInstance(e.WC, list,
+                                      derror.format('WC', 'list',
+                                                    type(e.WC)))
             if hasattr(e, 'subject'):
                 self.assertIsInstance(e.subject, list,
                                       derror.format('subject', 'list',


### PR DESCRIPTION
I changed the code to proper parse WC (web os science categories) keywords and remove the key 'DT' since it is duplicate (lines 82 and 88 at _tethne/readers/wos.py_).
